### PR TITLE
Syncing & Queued Deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 - [Kurt Friars](https://github.com/kfriars)
 - [Massimo Triassi](https://github.com/m-triassi)
-- [Andrew Hanichkovsky](https://github.com/a-drew)
 - [All Contributors](../../contributors)
 
 &nbsp;

--- a/config/publisher.php
+++ b/config/publisher.php
@@ -8,6 +8,7 @@ return [
         'draft' => 'draft',
         'workflow' => 'status',
         'has_been_published' => 'has_been_published',
+        'should_delete' => 'should_delete',
     ],
     'urls' => [
         'rewrite' => true,

--- a/src/Commands/PublisherMigrations.php
+++ b/src/Commands/PublisherMigrations.php
@@ -51,6 +51,7 @@ class PublisherMigrations extends Command
         $draftColumn = config()->get('publisher.columns.draft', 'draft');
         $workflowColumn = config()->get('publisher.columns.workflow', 'status');
         $unpublishedState = $model::workflow()::unpublished()->value;
+        $shouldDeleteColumn = config()->get('publisher.columns.should_delete', 'should_delete');
 
         return <<<EOT
         <?php
@@ -66,6 +67,7 @@ class PublisherMigrations extends Command
                     \$table->json('$draftColumn')->nullable();
                     \$table->string('$workflowColumn')->default('$unpublishedState');
                     \$table->boolean('$hasBeenPublishedColumn')->default(false);
+                    \$table->boolean('$shouldDeleteColumn')->default(false);
                 });
             }
 
@@ -75,6 +77,7 @@ class PublisherMigrations extends Command
                     \$table->dropColumn('$workflowColumn');
                     \$table->dropColumn('$draftColumn');
                     \$table->dropColumn('$hasBeenPublishedColumn');
+                    \$table->dropColumn('$shouldDeleteColumn');
                 });
             }
         };

--- a/src/Concerns/HasPublishableAttributes.php
+++ b/src/Concerns/HasPublishableAttributes.php
@@ -127,7 +127,7 @@ trait HasPublishableAttributes
             $this->draftColumn(),
             $this->hasBeenPublishedColumn(),
             $this->shouldDeleteColumn(),
-            $this->dependsOnPublishableForeignKey()
+            $this->dependsOnPublishableForeignKey(),
         ]);
 
         if (in_array(SoftDeletes::class, class_uses_recursive($this))) {

--- a/src/Concerns/HasPublishableAttributes.php
+++ b/src/Concerns/HasPublishableAttributes.php
@@ -126,6 +126,8 @@ trait HasPublishableAttributes
             $this->workflowColumn(),
             $this->draftColumn(),
             $this->hasBeenPublishedColumn(),
+            $this->shouldDeleteColumn(),
+            $this->dependsOnPublishableForeignKey()
         ]);
 
         if (in_array(SoftDeletes::class, class_uses_recursive($this))) {

--- a/src/Concerns/IsPublishable.php
+++ b/src/Concerns/IsPublishable.php
@@ -19,6 +19,7 @@ trait IsPublishable
 {
     use FiresPublishingEvents;
     use HasPublishableAttributes;
+    use SyncsPublishing;
 
     public function initializeIsPublishable()
     {
@@ -26,8 +27,13 @@ trait IsPublishable
         
         $this->{$this->workflowColumn()} ??= static::workflow()::unpublished();
         $this->{$this->hasBeenPublishedColumn()} ??= false;
+        $this->{$this->shouldDeleteColumn()} ??= false;
         
-        $this->makeHidden($this->draftColumn());
+        $this->makeHidden([
+            $this->draftColumn(),
+            $this->hasBeenPublishedColumn(),
+            $this->shouldDeleteColumn(),
+        ]);
     }
 
     protected function mergePublishableCasts(): void
@@ -36,6 +42,7 @@ trait IsPublishable
             $this->workflowColumn() => Status::class,
             $this->draftColumn() => 'json',
             $this->hasBeenPublishedColumn() => 'boolean',
+            $this->shouldDeleteColumn() => 'boolean',
         ]);
     }
 
@@ -111,6 +118,11 @@ trait IsPublishable
         return config()->get('publisher.columns.has_been_published', 'has_been_published');
     }
 
+    public function shouldDeleteColumn(): string
+    {
+        return config()->get('publisher.columns.should_delete', 'should_delete');
+    }
+
     /**
      * @return class-string<PublishingStatus>
      */
@@ -180,6 +192,6 @@ trait IsPublishable
 
     public function hasEverBeenPublished(): bool
     {
-        return $this->attributes[$this->hasBeenPublishedColumn()] === true;
+        return $this->{$this->hasBeenPublishedColumn()};
     }
 }

--- a/src/Concerns/IsPublishable.php
+++ b/src/Concerns/IsPublishable.php
@@ -24,11 +24,11 @@ trait IsPublishable
     public function initializeIsPublishable()
     {
         $this->mergePublishableCasts();
-        
+
         $this->{$this->workflowColumn()} ??= static::workflow()::unpublished();
         $this->{$this->hasBeenPublishedColumn()} ??= false;
         $this->{$this->shouldDeleteColumn()} ??= false;
-        
+
         $this->makeHidden([
             $this->draftColumn(),
             $this->hasBeenPublishedColumn(),

--- a/src/Concerns/QueriesPublishableModels.php
+++ b/src/Concerns/QueriesPublishableModels.php
@@ -29,6 +29,23 @@ trait QueriesPublishableModels
             ->whereNot($this->model->workflowColumn(), $this->model::workflow()::published());
     }
 
+    public function withoutQueuedDeletes(): Builder&PublisherQueries
+    {
+        return $this->withoutGlobalScope(PublisherScope::class)
+            ->where($this->model->shouldDeleteColumn(), false);
+    }
+
+    public function withQueuedDeletes(): Builder&PublisherQueries
+    {
+        return $this->withoutGlobalScope(PublisherScope::class);
+    }
+
+    public function onlyQueuedDeletes(): Builder&PublisherQueries
+    {
+        return $this->withoutGlobalScope(PublisherScope::class)
+            ->where($this->model->shouldDeleteColumn(), true);
+    }
+
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
         if ($column instanceof Closure && is_null($operator)) {

--- a/src/Concerns/SyncsPublishing.php
+++ b/src/Concerns/SyncsPublishing.php
@@ -81,7 +81,7 @@ trait SyncsPublishing
         return $this->{$this->dependendsOnPublishableRelation()};
     }
 
-    public function dependendsOnPublishableRelation(): string|null
+    public function dependendsOnPublishableRelation(): ?string
     {
         if (property_exists($this, 'dependendsOnPublishable')) {
             return $this->dependendsOnPublishable;
@@ -90,7 +90,7 @@ trait SyncsPublishing
         return null;
     }
 
-    public function dependsOnPublishableForeignKey(): string|null
+    public function dependsOnPublishableForeignKey(): ?string
     {
         if ($relation = $this->dependendsOnPublishableRelation()) {
             $relation = $this->{$relation}();
@@ -112,7 +112,7 @@ trait SyncsPublishing
 
         $models = [$this];
 
-        $relations = explode(".", $relation);
+        $relations = explode('.', $relation);
 
         while ($part = array_shift($relations)) {
             $results = [];

--- a/src/Concerns/SyncsPublishing.php
+++ b/src/Concerns/SyncsPublishing.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Plank\Publisher\Concerns;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Collection;
+use Plank\Publisher\Contracts\Publishable;
+
+/**
+ * @mixin FiresPublishingEvents
+ * @mixin Publishable
+ */
+trait SyncsPublishing
+{
+    public static function bootSyncsPublishing()
+    {
+        static::drafting(function (Publishable&Model $model) {
+            $model->syncPublishingToDependents();
+        });
+
+        static::undrafting(function (Publishable&Model $model) {
+            $model->syncPublishingToDependents();
+        });
+
+        static::deleting(function (Publishable&Model $model) {
+            return $model->queueForDelete();
+        });
+    }
+
+    public function syncPublishingToDependents(): void
+    {
+        $this->publishingDependents()
+            ->map(fn (string $relation) => $this->nestedPluck($relation))
+            ->flatten()
+            ->each(fn (Publishable&Model $model) => $model->syncPublishingFrom($this));
+    }
+
+    public function publishingDependents(): Collection
+    {
+        if (property_exists($this, 'publishingDependents')) {
+            return Collection::make($this->publishingDependents);
+        }
+
+        return Collection::make();
+    }
+
+    public function syncPublishingFrom(Publishable&Model $from): void
+    {
+        $this->setRelation($this->dependendsOnPublishableRelation(), $from);
+
+        $this->{$this->workflowColumn()} = $from->{$this->workflowColumn()};
+        $this->save();
+
+        if ($from->isPublished() && $this->{$this->shouldDeleteColumn()}) {
+            $this->delete();
+        }
+    }
+
+    public function queueForDelete(): ?bool
+    {
+        $parent = $this->dependendsOnPublishable();
+
+        if ($parent === null || $parent->isPublished()) {
+            return null;
+        }
+
+        $this->{$this->shouldDeleteColumn()} = true;
+        $this->save();
+
+        return false;
+    }
+
+    public function dependendsOnPublishable(): (Publishable&Model)|null
+    {
+        if ($this->dependendsOnPublishableRelation() === null) {
+            return null;
+        }
+
+        return $this->{$this->dependendsOnPublishableRelation()};
+    }
+
+    public function dependendsOnPublishableRelation(): string|null
+    {
+        if (property_exists($this, 'dependendsOnPublishable')) {
+            return $this->dependendsOnPublishable;
+        }
+
+        return null;
+    }
+
+    public function dependsOnPublishableForeignKey(): string|null
+    {
+        if ($relation = $this->dependendsOnPublishableRelation()) {
+            $relation = $this->{$relation}();
+        }
+
+        if ($relation instanceof BelongsTo) {
+            return $relation->getForeignKeyName();
+        }
+
+        return null;
+    }
+
+    /**
+     * @return Collection<Publishable&Model>
+     */
+    protected function nestedPluck(string $relation): Collection
+    {
+        $this->loadMissing($relation);
+
+        $models = [$this];
+
+        $relations = explode(".", $relation);
+
+        while ($part = array_shift($relations)) {
+            $results = [];
+
+            foreach ($models as $model) {
+                $related = $model->{$part};
+
+                if ($related instanceof Model) {
+                    $results[] = $related;
+
+                    continue;
+                }
+
+                if ($related instanceof Arrayable) {
+                    foreach ($related as $item) {
+                        $results[] = $item;
+                    }
+                }
+            }
+
+            $models = $results;
+        }
+
+        return Collection::make($models);
+    }
+}

--- a/src/Contracts/Publishable.php
+++ b/src/Contracts/Publishable.php
@@ -2,6 +2,9 @@
 
 namespace Plank\Publisher\Contracts;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
 interface Publishable extends PublishableAttributes, PublishableEvents
 {
     /**
@@ -18,6 +21,11 @@ interface Publishable extends PublishableAttributes, PublishableEvents
      * Get the name of the column that stores if the model has ever been published
      */
     public function hasBeenPublishedColumn(): string;
+
+    /**
+     * Get the name of the column that stores if the model should be deleted
+     */
+    public function shouldDeleteColumn(): string;
 
     /**
      * Get the Workflow State Enum
@@ -75,4 +83,43 @@ interface Publishable extends PublishableAttributes, PublishableEvents
      * Determine if the Model was recently saved as draft
      */
     public function wasUndrafted(): bool;
+
+    /**
+     * Sync the publishing state to dependents
+     */
+    public function syncPublishingToDependents(): void;
+
+    /**
+     * Sync the publishing state from another model
+     */
+    public function syncPublishingFrom(Publishable&Model $from): void;
+
+    /**
+     * Get a Collection of of dot-notation relations that should be synced 
+     * with this Model's publishing/visibility state.
+     * 
+     * @return Collection<string>
+     */
+    public function publishingDependents(): Collection;
+
+    /**
+     * Queue the model for deletion if it's owner is not published
+     */
+    public function queueForDelete(): ?bool;
+
+    /**
+     * Get the Model that this Model depends on for publishing/visibility
+     */
+    public function dependendsOnPublishable(): (Publishable&Model)|null;
+
+    /**
+     * Get the Model that this Model depends on for publishing/visibility
+     */
+    public function dependendsOnPublishableRelation(): string|null;
+
+    /**
+     * Get the Model the foreign key that this Model depends on for 
+     * publishing/visibility
+     */
+    public function dependsOnPublishableForeignKey(): string|null;
 }

--- a/src/Contracts/Publishable.php
+++ b/src/Contracts/Publishable.php
@@ -29,7 +29,7 @@ interface Publishable extends PublishableAttributes, PublishableEvents
 
     /**
      * Get the Workflow State Enum
-     * 
+     *
      * @return class-string<PublishingStatus>
      */
     public static function workflow(): string;
@@ -95,9 +95,9 @@ interface Publishable extends PublishableAttributes, PublishableEvents
     public function syncPublishingFrom(Publishable&Model $from): void;
 
     /**
-     * Get a Collection of of dot-notation relations that should be synced 
+     * Get a Collection of of dot-notation relations that should be synced
      * with this Model's publishing/visibility state.
-     * 
+     *
      * @return Collection<string>
      */
     public function publishingDependents(): Collection;
@@ -115,11 +115,11 @@ interface Publishable extends PublishableAttributes, PublishableEvents
     /**
      * Get the Model that this Model depends on for publishing/visibility
      */
-    public function dependendsOnPublishableRelation(): string|null;
+    public function dependendsOnPublishableRelation(): ?string;
 
     /**
-     * Get the Model the foreign key that this Model depends on for 
+     * Get the Model the foreign key that this Model depends on for
      * publishing/visibility
      */
-    public function dependsOnPublishableForeignKey(): string|null;
+    public function dependsOnPublishableForeignKey(): ?string;
 }

--- a/src/Contracts/PublisherQueries.php
+++ b/src/Contracts/PublisherQueries.php
@@ -15,4 +15,19 @@ interface PublisherQueries
      * Scope the query to models that are not in the published state
      */
     public function onlyDraft(): Builder&PublisherQueries;
+
+    /**
+     * Scope the query to models that are not queued for deletion
+     */
+    public function withoutQueuedDeletes(): Builder&PublisherQueries;
+
+    /**
+     * Scope the query to models that are queued for deletion
+     */
+    public function onlyQueuedDeletes(): Builder&PublisherQueries;
+
+    /**
+     * Scope the query to models that are either queued for deletion or not
+     */
+    public function withQueuedDeletes(): Builder&PublisherQueries;
 }

--- a/src/Contracts/PublishingStatus.php
+++ b/src/Contracts/PublishingStatus.php
@@ -5,6 +5,6 @@ namespace Plank\Publisher\Contracts;
 interface PublishingStatus
 {
     public static function published(): self;
-    
+
     public static function unpublished(): self;
 }

--- a/src/Enums/Status.php
+++ b/src/Enums/Status.php
@@ -4,7 +4,7 @@ namespace Plank\Publisher\Enums;
 
 use Plank\Publisher\Contracts\PublishingStatus;
 
-enum Status: string implements PublishingStatus 
+enum Status: string implements PublishingStatus
 {
     case DRAFT = 'draft';
     case PUBLISHED = 'published';

--- a/tests/Feature/SyncPublishingTest.php
+++ b/tests/Feature/SyncPublishingTest.php
@@ -1,0 +1,127 @@
+<?php
+
+use Plank\Publisher\Enums\Status;
+use Plank\Publisher\Facades\Publisher;
+use Plank\Publisher\Tests\Helpers\Models\Post;
+use Plank\Publisher\Tests\Helpers\Models\Section;
+
+beforeEach(function () {
+    Publisher::allowDraftContent();
+});
+
+it('publishes all dependent content when its parent is published', function () {
+    $post = Post::factory()->create([
+        'status' => Status::DRAFT,
+    ]);
+
+    $sections = Section::factory(3)->create([
+        'post_id' => $post->id,
+        'status' => Status::DRAFT,
+    ]);
+
+    $post->status = Status::PUBLISHED;
+    $post->save();
+
+    $sections->each(function ($section) {
+        expect($section->fresh()->status)->toBe(Status::PUBLISHED);
+    });
+});
+
+it('unpublishes all dependent content when its parent is unpublished', function () {
+    $post = Post::factory()->create([
+        'status' => Status::PUBLISHED,
+    ]);
+
+    $sections = Section::factory(3)->create([
+        'post_id' => $post->id,
+        'status' => Status::PUBLISHED,
+    ]);
+
+    $post->status = Status::DRAFT;
+    $post->save();
+
+    $sections->each(function ($section) {
+        expect($section->fresh()->status)->toBe(Status::DRAFT);
+    });
+});
+
+it('does not delete dependent content when its parent is in draft', function () {
+    $post = Post::factory()->create([
+        'status' => Status::DRAFT,
+    ]);
+
+    $sections = Section::factory(3)->create([
+        'post_id' => $post->id,
+        'status' => Status::DRAFT,
+    ]);
+
+    $section = $sections->first();
+    $section->delete();
+    expect($post->sections()->withoutQueuedDeletes()->count())->toBe(2);
+    expect($post->sections()->count())->toBe(3);
+    expect($section->should_delete)->toBeTrue();
+});
+
+it('deletes dependent content when its parent is published', function () {
+    $post = Post::factory()->create([
+        'status' => Status::PUBLISHED,
+    ]);
+
+    $sections = Section::factory(3)->create([
+        'post_id' => $post->id,
+        'status' => Status::PUBLISHED,
+    ]);
+
+    $section = $sections->first();
+    $section->delete();
+    expect($post->sections()->withoutQueuedDeletes()->count())->toBe(2);
+    expect($post->sections()->count())->toBe(2);
+    expect($section->should_delete)->toBeFalse();
+});
+
+it('deletes dependent content queued to be deleted when its parent is published', function () {
+    $post = Post::factory()->create([
+        'status' => Status::DRAFT,
+    ]);
+
+    $sections = Section::factory(3)->create([
+        'post_id' => $post->id,
+        'status' => Status::DRAFT,
+    ]);
+
+    $section = $sections->first();
+    $section->delete();
+    expect($post->sections()->withoutQueuedDeletes()->count())->toBe(2);
+    expect($post->sections()->count())->toBe(3);
+    expect($section->should_delete)->toBeTrue();
+
+    $post->status = Status::PUBLISHED;
+    $post->save();
+
+    expect($post->sections()->withoutQueuedDeletes()->count())->toBe(2);
+    expect($post->sections()->count())->toBe(2);
+});
+
+it('does not delete dependent content queued to be deleted when its parent is saved in a non-published state', function () {
+    $post = Post::factory()->create([
+        'status' => Status::DRAFT,
+    ]);
+
+    $sections = Section::factory(3)->create([
+        'post_id' => $post->id,
+        'status' => Status::DRAFT,
+    ]);
+
+    $section = $sections->first();
+    $section->delete();
+
+    expect($post->sections()->withoutQueuedDeletes()->count())->toBe(2);
+    expect($post->sections()->count())->toBe(3);
+    expect($section->should_delete)->toBeTrue();
+
+    $post->title .= ' – Updated';
+    $post->save();
+
+    expect($post->sections()->withoutQueuedDeletes()->count())->toBe(2);
+    expect($post->sections()->count())->toBe(3);
+});

--- a/tests/Helpers/Database/Factories/SectionFactory.php
+++ b/tests/Helpers/Database/Factories/SectionFactory.php
@@ -5,22 +5,21 @@ namespace Plank\Publisher\Tests\Helper\Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Plank\Publisher\Enums\Status;
 use Plank\Publisher\Tests\Helpers\Models\Post;
-use Plank\Publisher\Tests\Helpers\Models\User;
+use Plank\Publisher\Tests\Helpers\Models\Section;
 
-class PostFactory extends Factory
+class SectionFactory extends Factory
 {
-    protected $model = Post::class;
+    protected $model = Section::class;
 
     public function definition()
     {
-        $title = $this->faker->words($this->faker->numberBetween(2, 4), true);
+        $heading = $this->faker->words($this->faker->numberBetween(2, 4), true);
         $status = $this->faker->randomElement(Status::cases());
 
         $attributes = [
-            'author_id' => User::query()->inRandomOrder()->first()?->id ?? User::factory(),
-            'title' => $title,
-            'slug' => (string) str($title)->slug(),
-            'body' => $this->faker->paragraphs($this->faker->numberBetween(1, 3), true),
+            'post_id' => Post::query()->inRandomOrder()->first()?->id ?? Post::factory(),
+            'heading' => $heading,
+            'text' => $this->faker->paragraphs($this->faker->numberBetween(1, 3), true),
         ];
 
         return [

--- a/tests/Helpers/Database/Migrations/2023_06_16_000008_create_sections_table.php
+++ b/tests/Helpers/Database/Migrations/2023_06_16_000008_create_sections_table.php
@@ -8,21 +8,20 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('sections', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('author_id');
-            $table->string('title');
-            $table->string('slug');
-            $table->text('body');
+            $table->unsignedBigInteger('post_id');
+            $table->string('heading');
+            $table->text('text');
             $table->string('status');
             $table->boolean('has_been_published')->default(false);
             $table->json('draft')->nullable();
             $table->boolean('should_delete')->default(false);
             $table->timestamps();
 
-            $table->foreign('author_id')
+            $table->foreign('post_id')
                 ->references('id')
-                ->on('users')
+                ->on('posts')
                 ->nullOnDelete();
         });
     }

--- a/tests/Helpers/Models/Post.php
+++ b/tests/Helpers/Models/Post.php
@@ -12,6 +12,13 @@ class Post extends TestModel implements Publishable
 {
     use IsPublishable;
 
+    protected array $publishingDependents = ['sections'];
+
+    public function sections(): HasMany
+    {
+        return $this->hasMany(Section::class, 'post_id');
+    }
+
     public function author(): BelongsTo
     {
         return $this->belongsTo(User::class, 'author_id');

--- a/tests/Helpers/Models/Section.php
+++ b/tests/Helpers/Models/Section.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Plank\Publisher\Tests\Helpers\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Plank\Publisher\Concerns\IsPublishable;
+use Plank\Publisher\Contracts\Publishable;
+
+class Section extends TestModel implements Publishable
+{
+    use IsPublishable;
+
+    public string $dependendsOnPublishable = 'post';
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class, 'post_id');
+    }
+}


### PR DESCRIPTION
## Summary
In order for drafted content to be able to have "dependent" content, we add the notion if syncing and queued deleted.

Status is always synced to dependents when content is saved.
Deletes are queued on dependent content until the parent is published.

## Tests
1. SyncPublishingTest