### PR TITLE
Allow the workflow cast to be customized

### DIFF
--- a/src/Concerns/IsPublishable.php
+++ b/src/Concerns/IsPublishable.php
@@ -39,7 +39,7 @@ trait IsPublishable
     protected function mergePublishableCasts(): void
     {
         $this->mergeCasts([
-            $this->workflowColumn() => Status::class,
+            $this->workflowColumn() => config()->get('publisher.workflow'),
             $this->draftColumn() => 'json',
             $this->hasBeenPublishedColumn() => 'boolean',
             $this->shouldDeleteColumn() => 'boolean',

--- a/src/Concerns/IsPublishable.php
+++ b/src/Concerns/IsPublishable.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Plank\Publisher\Builders\PublisherBuilder;
 use Plank\Publisher\Contracts\Publishable;
 use Plank\Publisher\Contracts\PublishingStatus;
-use Plank\Publisher\Enums\Status;
 use Plank\Publisher\Facades\Publisher;
 use Plank\Publisher\Scopes\PublisherScope;
 

--- a/tests/Feature/DraftPathsTest.php
+++ b/tests/Feature/DraftPathsTest.php
@@ -3,8 +3,8 @@
 use function Pest\Laravel\get;
 
 it('correctly forces draft content on the configured draft_paths', function () {
-    get('pages/1')->assertSee('Draft Content Restricted');
+get('pages/1')->assertSee('Draft Content Restricted');
     get('admin')->assertSee('Draft Content Visible');
     get('admin/dashboard')->assertSee('Draft Content Visible');
     get('admin/resources/pages/1/details')->assertSee('Draft Content Visible');
-});
+    });

--- a/tests/Feature/InstallationTest.php
+++ b/tests/Feature/InstallationTest.php
@@ -51,7 +51,7 @@ it('does not publish the config file when not confirmed', function () {
 
 it('publishes the migrations file when confirmed', function () {
     Publisher::shouldReceive('publishableModels')
-        ->andReturn(collect([new Post()]));
+        ->andReturn(collect([new Post]));
 
     artisan('publisher:install')
         ->expectsConfirmation('⚠️ Please ensure you have added the \Plank\Publisher\Contracts\Publishable interface to the models you wish to be publishable. Continue?', 'yes')


### PR DESCRIPTION
## Summary
There was a bug where changing the workflow cast in the config file would throw an exception during initialization as the cast definition was not using the configured value.