### PR TITLE
Add method to revert draft changes on a model

### DIFF
--- a/src/Contracts/Publishable.php
+++ b/src/Contracts/Publishable.php
@@ -8,6 +8,11 @@ use Illuminate\Support\Collection;
 interface Publishable extends PublishableAttributes, PublishableEvents
 {
     /**
+     * Drop all draft changes and restore the model as published
+     */
+    public function revert(): void;
+
+    /**
      * Get the name of the column that stores the draft attributes
      */
     public function draftColumn(): string;

--- a/src/Exceptions/PublisherException.php
+++ b/src/Exceptions/PublisherException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Plank\Publisher\Exceptions;
+
+use Exception;
+
+class PublisherException extends Exception {}

--- a/src/Exceptions/RevertException.php
+++ b/src/Exceptions/RevertException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Plank\Publisher\Exceptions;
+
+class RevertException extends PublisherException {}

--- a/src/Facades/Publisher.php
+++ b/src/Facades/Publisher.php
@@ -2,6 +2,7 @@
 
 namespace Plank\Publisher\Facades;
 
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -16,6 +17,8 @@ use Plank\Publisher\Contracts\Publishable;
  * @method static bool draftContentRestricted()
  * @method static void allowDraftContent()
  * @method static void restrictDraftContent()
+ * @method static mixed withDraftContent(Closure $closure)
+ * @method static mixed withoutDraftContent(Closure $closure)
  * @method static Collection<Model&Publishable> publishableModels()
  */
 class Publisher extends Facade

--- a/src/Services/PublisherService.php
+++ b/src/Services/PublisherService.php
@@ -2,6 +2,7 @@
 
 namespace Plank\Publisher\Services;
 
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -65,6 +66,26 @@ class PublisherService
     public function restrictDraftContent(): void
     {
         $this->draftContentAllowed = false;
+    }
+
+    public function withDraftContent(Closure $closure): mixed
+    {
+        $scope = $this->draftContentAllowed;
+        $this->draftContentAllowed = true;
+        $result = $closure();
+        $this->draftContentAllowed = $scope;
+
+        return $result;
+    }
+
+    public function withoutDraftContent(Closure $closure): mixed
+    {
+        $scope = $this->draftContentAllowed;
+        $this->draftContentAllowed = false;
+        $result = $closure();
+        $this->draftContentAllowed = $scope;
+
+        return $result;
     }
 
     /**

--- a/tests/Feature/PublishedTest.php
+++ b/tests/Feature/PublishedTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Plank\Publisher\Enums\Status;
+use Plank\Publisher\Exceptions\RevertException;
 use Plank\Publisher\Tests\Helpers\Models\Post;
 use Plank\Publisher\Tests\Helpers\Models\User;
 
@@ -49,3 +50,48 @@ it('maintains has_been_published state after unpublishing', function () {
     $this->assertEquals(Status::unpublished(), $post->status);
     $this->assertTrue($post->hasEverBeenPublished());
 });
+
+it('allows revert for content that has been published', function () {
+    /** @var Post $post */
+    $post = Post::create([
+        'author_id' => User::first()->id,
+        'title' => 'My First Post',
+        'slug' => 'my-first-post',
+        'body' => 'This is the body of my first post.',
+        'status' => Status::published(),
+    ]);
+
+    $this->assertEquals(Status::published(), $post->status);
+    $this->assertTrue($post->hasEverBeenPublished());
+
+    $post->update([
+        'status' => 'draft',
+    ]);
+
+    $post->update([
+        'title' => 'My Updated Post',
+    ]);
+
+    $this->assertEquals(Status::unpublished(), $post->status);
+    $this->assertTrue($post->hasEverBeenPublished());
+
+    $post->revert();
+
+    $this->assertEquals(Status::published(), $post->status);
+    $this->assertNull($post->draft);
+    $this->assertEquals('My First Post', $post->title);
+});
+
+it('does nothing for revert when content has never been published', function () {
+    /** @var Post $post */
+    $post = Post::create([
+        'author_id' => User::first()->id,
+        'title' => 'My First Post',
+        'slug' => 'my-first-post',
+        'body' => 'This is the body of my first post.',
+        'status' => Status::unpublished(),
+    ]);
+
+    $this->assertFalse($post->hasEverBeenPublished());
+    $post->revert();
+})->throws(RevertException::class);


### PR DESCRIPTION
## Summary
Add a method that can revert draft changes on a model that has been published before.

## Tests
- allows revert for content that has been published
- does nothing for revert when content has never been published